### PR TITLE
Bug fix for when login item is nil

### DIFF
--- a/NoiseBuddy/Support/SharedFileList.m
+++ b/NoiseBuddy/Support/SharedFileList.m
@@ -63,7 +63,9 @@ void sharedFileListDidChange(LSSharedFileListRef inList, void *context);
         CFURLRef currentItemURL = NULL;
         LSSharedFileListItemResolve(item, resolutionFlags, &currentItemURL, NULL);
         NSURL *itemURL = CFBridgingRelease(currentItemURL);
-        [snapshot addObject:itemURL];
+        if (itemURL != nil) {
+            [snapshot addObject:itemURL];
+        }
     }
     
     return snapshot;


### PR DESCRIPTION
I'm new to Objective-C so there might be a better way of doing this but I was noticing crash when a login item was nil and trying to be added. Skype was the culprit 🤨

This would prevent the prefs window from updating the UI after login item.

![Screen Shot 2020-02-08 at 11 41 07 AM](https://user-images.githubusercontent.com/6733030/74091417-28397900-4a6c-11ea-9136-c0fcbd9cf4d2.png)
![Screen Shot 2020-02-08 at 11 41 21 AM](https://user-images.githubusercontent.com/6733030/74091418-296aa600-4a6c-11ea-96fb-c815c76d1c0e.png)
