### PR TITLE
Fix tooltip not updating on listening mode change

### DIFF
--- a/NoiseBuddy/Controllers/MenuBarUIController.swift
+++ b/NoiseBuddy/Controllers/MenuBarUIController.swift
@@ -38,6 +38,7 @@ final class MenuBarUIController: NoiseControlUIController {
 
     override func handleListeningModeDidChange(_ device: NCDevice) {
         item?.button?.image = device.listeningMode.menuBarImage
+        item?.button?.toolTip = currentDevice?.tooltip
     }
 
     override func handleDeviceDidChange(_ device: NCDevice?) {


### PR DESCRIPTION
When the listening mode changes, the tooltip wasn't being updated to reflect the new mode.

| Before | After |
|--|--|
|![before](https://user-images.githubusercontent.com/1749664/92162219-ba023c80-ee29-11ea-9404-9589ca1826cd.gif)|![after](https://user-images.githubusercontent.com/1749664/92162217-b969a600-ee29-11ea-8414-70fdfe8eab8e.gif)|
